### PR TITLE
Add intl extension support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,7 @@ CONFIGURE_STRING="--prefix=/usr/local/php7 \
                   --enable-bcmath \
                   --with-bz2 \
                   --enable-calendar \
+                  --enable-intl \
                   --enable-exif \
                   --enable-dba \
                   --enable-ftp \

--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,15 @@ cd "$(dirname "$0")"
 sudo apt-get update
 sudo apt-get install -y \
     build-essential \
+    pkg-config \
     git-core \
     autoconf \
     bison \
     libxml2-dev \
     libbz2-dev \
     libmcrypt-dev \
+    libicu-dev \
+    libssl-dev \
     libcurl4-openssl-dev \
     libltdl-dev \
     libjpeg-dev \

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,7 @@ Note that most of the third-party PHP extensions are [not yet compatible with PH
 	gettext
 	hash
 	iconv
+	intl
 	json
 	libxml
 	mbstring


### PR DESCRIPTION
This is a very common extension, used in most PHP Frameworks.

Tested on Debian Jessie.

PS: I have another branch with systemd support for Jessie, with a unit file instead of the old deprecated init script, donno exactly how to create the pull request for it.
