### PR TITLE
Speedup php7 source retrieval

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ sudo apt-get install -y \
 
 sudo mkdir /usr/local/php7
 
-git clone https://github.com/php/php-src.git
+git clone -b PHP-7.0.0 --depth=1 https://github.com/php/php-src.git
 cd php-src
 git checkout PHP-7.0.0
 git pull


### PR DESCRIPTION
It is an install process, so we don't need the whole tree.
Clone only the latest level of the repository.

**Fix: Properly retrieve targeted branch**
I didn't remove the checkout and pull, but it should be ok to do so.

I got a little too fast this morning, and I tested it improperly on a half-downloaded repo.
Thanks to the `git pull`, I worked anyway but I missed any warnings on the branch retrieval process.

_Sorry for the mess :'(_
