### PR TITLE
Added fpm systemd support for Jessie

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ sudo apt-get install -y \
     libjpeg-dev \
     libpng-dev \
     libpspell-dev \
+    libsystemd-daemon-dev \
     libreadline-dev
 
 sudo mkdir /usr/local/php7
@@ -64,6 +65,7 @@ CONFIGURE_STRING="--prefix=/usr/local/php7 \
                   --with-readline \
                   --with-curl \
                   --enable-fpm \
+                  --with-fpm-systemd \
                   --with-fpm-user=www-data \
                   --with-fpm-group=www-data"
 

--- a/conf/php7-fpm-checkconf
+++ b/conf/php7-fpm-checkconf
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+errors=$(/usr/local/php7/sbin/php-fpm --fpm-config /usr/local/php7/etc/php-fpm.conf -t 2>&1 | grep "\[ERROR\]" || true);
+if [ -n "$errors" ]; then
+    echo "Please fix your configuration file…"
+    echo $errors
+    exit 1
+fi
+exit 0

--- a/conf/php7-fpm.service
+++ b/conf/php7-fpm.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=The PHP 7 FastCGI Process Manager
+After=network.target
+
+[Service]
+Type=notify
+PIDFile=/var/run/php7-fpm.pid
+ExecStartPre=/usr/local/lib/php7-fpm-checkconf
+ExecStart=/usr/local/php7/sbin/php-fpm --fpm-config /usr/local/php7/etc/php-fpm.conf
+ExecReload=/bin/kill -USR2 $MAINPID
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I just tested this on my machine, but I don't know if it should be a new branch, as it probably doesn't work on Wheezy.

```
vagrant@aboutyou:~/php-7-debian$ sudo service php7-fpm status
● php7-fpm.service - The PHP 7 FastCGI Process Manager
   Loaded: loaded (/etc/systemd/system/php7-fpm.service; enabled)
   Active: active (running) since Wed 2016-01-13 15:48:46 CET; 12s ago
  Process: 21686 ExecStartPre=/usr/local/lib/php7-fpm-checkconf (code=exited, status=0/SUCCESS)
 Main PID: 21693 (php-fpm)
   Status: "Processes active: 0, idle: 10, Requests: 0, slow: 0, Traffic: 0req/sec"
   CGroup: /system.slice/php7-fpm.service
           ├─21693 php-fpm: master process (/usr/local/php7/etc/php-fpm.conf)
           ├─21694 php-fpm: pool www
           ├─21695 php-fpm: pool www
           ├─21696 php-fpm: pool www
```
